### PR TITLE
[PR] change http link to google to use https

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@ button.gsc-search-button
 					<div class = "search-field" style="width:472px; align-content: left; display: inline-block; background-color: #ffffff ;color:rgb(0,0,0); ">
 						<center>
                         <BR>
-						 <span><form action="http://google.com/search?q=site%3Acryptodoneright.org" target="_self">
+						 <span><form action="https://google.com/search?q=site%3Acryptodoneright.org" target="_self">
                         <input type="hidden" name="q" value="site:cryptodoneright.org">
                         <input name="q">
                                 <input type="submit">


### PR DESCRIPTION
## Description
> the link to submit the search to google uses http. This causes warnings in web browsers when submitting from the website (https://cryptodoneright.org/). https should be used, this is also googles recommendation. 


##  This pull request includes a:
###### (You can select by putting a 'x' in '[ ]' without any spaces. ( - [ x ])
- [ ] Code bug fix
- [ ] Current content fix (update outdated contents, error fix, proofreading, etc.)
- [ ] New content creation
- [x ] Website UI modifications
- [ ] Others (please specify)
> Specify "Others" here: 

## Changes Made

###### Please states the changes you have made in this pull request.
> - in index.html
http://google.com/search?q=site%3Acryptodoneright.org
to:
https://google.com/search?q=site%3Acryptodoneright.org


## Related Issues
None.

## How Has This Been Tested/Verified 
If applicable, please states how the changes have been tested, verified, or validated.

Made the change and tested to make a search on local site/content.

## Check List
- [x ] My code follows the code style of this project.
- [x ] I have read the CONTRIBUTING document.
- [ ] My change requires a change to the documentation.
