### PR TITLE
Fixed FAQ link error that did not include the HTML extension.

### DIFF
--- a/_includes/best_practices.html
+++ b/_includes/best_practices.html
@@ -33,5 +33,5 @@
 
      </OL>
      <p>
-     For more details check <A HREF="FAQ">the FAQ</A> for this algorithm.
-    </.p>
+     For more details check <A HREF="FAQ.html">the FAQ</A> for this algorithm.
+    </p>


### PR DESCRIPTION
---
name: pull_request_template.md
about: This is the official template for pull requests.
---

## Description
> The best practices template has a link to FAQ. But the link was missing the ".html" extension. This pull request fixes that error.


##  This pull request includes a:
###### (You can select by putting a 'x' in '[ ]' without any spaces. ( - [ x ])
- [x] Code bug fix
- [ ] Current content fix (update outdated contents, error fix, proofreading, etc.)
- [ ] New content creation
- [ ] Website UI modifications
- [ ] Others (please specify)
> Specify "Others" here: 

## Changes Made

###### Please states the changes you have made in this pull request.
> - Added the .html extension to the FAQ link
> -
> -

## Related Issues
If this is related to an existing ticket, please include a link to it as well.
> 

## How Has This Been Tested/Verified 
If applicable, please states how the changes have been tested, verified, or validated.
> Tested locally using jekyll serve.

## Check List
- [x] My code follows the code style of this project.
- [x] I have read the CONTRIBUTING document.
- [ ] My change requires a change to the documentation.
